### PR TITLE
Fix: Corrected remote path for DQN (was pointing to Rainbow).

### DIFF
--- a/atari_zoo/config.py
+++ b/atari_zoo/config.py
@@ -23,7 +23,7 @@ datadir_remote_dict = {'apex':"https://dgqeqexrlnkvd.cloudfront.net/zoo/apex",
                          'ga':"https://dgqeqexrlnkvd.cloudfront.net/zoo/ga",
                          'a2c':"https://dgqeqexrlnkvd.cloudfront.net/zoo/a2c",
                          'rainbow':"https://dgqeqexrlnkvd.cloudfront.net/zoo/rainbow",
-                       'dqn':"https://dgqeqexrlnkvd.cloudfront.net/zoo/rainbow"}
+                       'dqn':"https://dgqeqexrlnkvd.cloudfront.net/zoo/dqn"}
 
 url_formatter_dict = {('rainbow','remote'):dopamine_url_formatter,('dqn','remote'):dopamine_url_formatter}
 


### PR DESCRIPTION
Just a one line thing